### PR TITLE
[RBHW-360] Allow client to be passed in to provider

### DIFF
--- a/src/provider.test.tsx
+++ b/src/provider.test.tsx
@@ -4,6 +4,7 @@ jest.mock('./context', () => ({ Provider: 'Provider' }));
 import * as React from 'react';
 import { create } from 'react-test-renderer';
 import { shallow } from 'enzyme';
+import type { LDClient } from 'launchdarkly-js-client-sdk';
 import { LDFlagChangeset, LDFlagSet, LDOptions, LDUser } from 'launchdarkly-js-client-sdk';
 import initLDClient from './initLDClient';
 import { LDReactOptions, EnhancedComponent, defaultReactOptions, ProviderConfig } from './types';
@@ -18,6 +19,7 @@ const mockLDClient = {
   on: jest.fn((e: string, cb: () => void) => {
     cb();
   }),
+  allFlags: jest.fn().mockReturnValue({}),
 };
 
 describe('LDProvider', () => {
@@ -47,6 +49,61 @@ describe('LDProvider', () => {
     const user: LDUser = { key: 'yus', name: 'yus ng' };
     const options: LDOptions = { bootstrap: {} };
     const props: ProviderConfig = { clientSideID, user, options };
+    const LaunchDarklyApp = (
+      <LDProvider {...props}>
+        <App />
+      </LDProvider>
+    );
+    const instance = create(LaunchDarklyApp).root.findByType(LDProvider).instance as EnhancedComponent;
+
+    await instance.componentDidMount();
+    expect(mockInitLDClient).toHaveBeenCalledWith(clientSideID, user, defaultReactOptions, options, undefined);
+  });
+
+  test('ld client is used if passed in', async () => {
+    const user: LDUser = { key: 'yus', name: 'yus ng' };
+    const options: LDOptions = { bootstrap: {} };
+    const ldClient = (await initLDClient(clientSideID, user, defaultReactOptions, options, undefined)).ldClient;
+    mockInitLDClient.mockClear();
+    const props: ProviderConfig = { clientSideID, ldClient };
+    const LaunchDarklyApp = (
+      <LDProvider {...props}>
+        <App />
+      </LDProvider>
+    );
+    const instance = create(LaunchDarklyApp).root.findByType(LDProvider).instance as EnhancedComponent;
+
+    await instance.componentDidMount();
+    expect(mockInitLDClient).not.toHaveBeenCalled();
+  });
+
+  test('ld client is used if passed in as promise', async () => {
+    const user: LDUser = { key: 'yus', name: 'yus ng' };
+    const options: LDOptions = { bootstrap: {} };
+    const ldClient: Promise<LDClient> = new Promise(async resolve =>
+      resolve((await initLDClient(clientSideID, user, defaultReactOptions, options, undefined)).ldClient),
+    );
+    mockInitLDClient.mockClear();
+    const props: ProviderConfig = { clientSideID, ldClient };
+    const LaunchDarklyApp = (
+      <LDProvider {...props}>
+        <App />
+      </LDProvider>
+    );
+    const instance = create(LaunchDarklyApp).root.findByType(LDProvider).instance as EnhancedComponent;
+
+    await instance.componentDidMount();
+    expect(mockInitLDClient).not.toHaveBeenCalled();
+  });
+
+  test('ld client is created if passed in promise resolves as undefined', async () => {
+    const user: LDUser = { key: 'yus', name: 'yus ng' };
+    const options: LDOptions = { bootstrap: {} };
+    const ldClient: Promise<undefined> = new Promise(async resolve =>
+      resolve(undefined),
+    );
+    mockInitLDClient.mockClear();
+    const props: ProviderConfig = { clientSideID, ldClient, user, options };
     const LaunchDarklyApp = (
       <LDProvider {...props}>
         <App />

--- a/src/provider.test.tsx
+++ b/src/provider.test.tsx
@@ -78,13 +78,13 @@ describe('LDProvider', () => {
   });
 
   test('ld client is used if passed in as promise', async () => {
-    const user: LDUser = { key: 'yus', name: 'yus ng' };
+    const user1: LDUser = { key: 'yus', name: 'yus ng' };
+    const user2: LDUser = { key: 'launch', name: 'darkly' };
     const options: LDOptions = { bootstrap: {} };
     const ldClient: Promise<LDClient> = new Promise(async resolve =>
-      resolve((await initLDClient(clientSideID, user, defaultReactOptions, options, undefined)).ldClient),
+      resolve((await initLDClient(clientSideID, user1, defaultReactOptions, options, undefined)).ldClient),
     );
-    mockInitLDClient.mockClear();
-    const props: ProviderConfig = { clientSideID, ldClient };
+    const props: ProviderConfig = { clientSideID, ldClient, user: user2 };
     const LaunchDarklyApp = (
       <LDProvider {...props}>
         <App />
@@ -93,7 +93,8 @@ describe('LDProvider', () => {
     const instance = create(LaunchDarklyApp).root.findByType(LDProvider).instance as EnhancedComponent;
 
     await instance.componentDidMount();
-    expect(mockInitLDClient).not.toHaveBeenCalled();
+    expect(mockInitLDClient).toBeCalledTimes(1);
+    expect(mockInitLDClient).toHaveBeenCalledWith(clientSideID, user1, defaultReactOptions, options, undefined);
   });
 
   test('ld client is created if passed in promise resolves as undefined', async () => {
@@ -102,7 +103,6 @@ describe('LDProvider', () => {
     const ldClient: Promise<undefined> = new Promise(async resolve =>
       resolve(undefined),
     );
-    mockInitLDClient.mockClear();
     const props: ProviderConfig = { clientSideID, ldClient, user, options };
     const LaunchDarklyApp = (
       <LDProvider {...props}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,12 @@ export interface ProviderConfig {
    * Otherwise, all flags will be requested and listened to.
    */
   flags?: LDFlagSet;
+
+  /**
+   * Optionally, the LDClient can be initialised outside of the provider
+   * and passed in, instead of being initialised by the provider.
+   */
+  ldClient?: LDClient | Promise<LDClient | undefined>;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,8 +73,10 @@ export interface ProviderConfig {
   flags?: LDFlagSet;
 
   /**
-   * Optionally, the LDClient can be initialised outside of the provider
+   * Optionally, the ldClient can be initialised outside of the provider
    * and passed in, instead of being initialised by the provider.
+   * Note: it should only be passed in when it has emitted the 'ready'
+   * event, to ensure that the flags are properly set.
    */
   ldClient?: LDClient | Promise<LDClient | undefined>;
 }


### PR DESCRIPTION
Allow client to be passed in, instead of initialising in `LDProvider`